### PR TITLE
FSGuess: 0xE9 is also a valid jump instruction

### DIFF
--- a/FATtools/utils.py
+++ b/FATtools/utils.py
@@ -58,7 +58,7 @@ def FSguess(boot):
     "Try to guess the file system type between FAT12/16/32, exFAT and NTFS examining the boot sector"
     # if no signature or JMP opcode, it is not valid
     #~ print boot._buf[0], ord(boot._buf[0]), hex(ord(boot._buf[0]))
-    if boot.wBootSignature != 0xAA55 or boot._buf[0] not in ('\xEB', 0xEB):
+    if boot.wBootSignature != 0xAA55 or boot._buf[0] not in ('\xEB', 0xEB, '\xE9', 0xE9):
         return 'NONE'
     if boot.chOemID.startswith(b'NTFS'):
         return 'NTFS'


### PR DESCRIPTION
As per subject.

`0xE9` is also allowed in the *jump instruction* part of a boot record. See [Design of the FAT file system: Reserved sectors area: Boot Sector](https://en.wikipedia.org/wiki/Design_of_the_FAT_file_system#Boot_Sector) for instance.

I had a view images which `FATtools` failed to open as it only checked for `0xEB`.

After making this change, they all opened successfully.
