### PR TITLE
Read disk from memory, ANSI decode linux workaround

### DIFF
--- a/FATtools/FAT.py
+++ b/FATtools/FAT.py
@@ -1207,7 +1207,10 @@ class FATDirentry(Direntry):
         if DEBUG&4: log("GetShortName got %s:%d",shortname,chFlags)
         if type(shortname) != str:
             #~ shortname = shortname.decode()
-            shortname = shortname.decode('ansi') # fix b'XXXXXX~1\xfaTH'
+            if os.name == 'nt':
+                shortname = shortname.decode('ansi') # fix b'XXXXXX~1\xfaTH'
+            else:
+                shortname = shortname.decode('cp437')
         name = shortname[:8].rstrip()
         if chFlags & 0x8: name = name.lower()
         ext = shortname[8:].rstrip()

--- a/FATtools/disk.py
+++ b/FATtools/disk.py
@@ -140,7 +140,10 @@ class disk(object):
         self.cache_dirties = {} # dirty sectors
         self.cache_table = {} # { sector: cache offset }
         self.cache_tableR = {} # reversed: { cache offset:sector }
-        if os.name == 'nt' and '\\\\.\\' in name:
+        if mode == 'ramdisk':
+            self._file = name
+            self.size = name.getbuffer().nbytes
+        elif os.name == 'nt' and '\\\\.\\' in name:
             self._file = win32_disk(name, mode, buffering)
             self.size = self._file.size
         else:


### PR DESCRIPTION
Hello,
I recently had the need to read data from small FAT images Bytes streams in RAM and I had a really hard time to find a library supporting this feature, so I decided to patch FATtools to accept BytesIO streams. I also had to fix filename ansi decoding on linux, since it is not supported on any other platform than Windows. pyfatfs appears to be [using](https://github.com/nathanhi/pyfatfs/blob/master/pyfatfs/__init__.py#L21) `cp437`, so I have added a simple check for the platform and called it a day.

I'd like to point out that I wasn't 100% sure about this PR since my code looks really hacky to me, and I have to admit I haven't tested any write operation. Complete support was outside the scope of my project, thus I had no interest in doing it, but you're free to reject this PR