### PR TITLE
pyproject.toml: fix broken package due to missing NTFS submodule

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,7 @@ homepage = "https://github.com/maxpat78/FATtools"
 repository = "https://github.com/maxpat78/FATtools.git"
 
 [tool.setuptools]
-packages = ["FATtools", "FATtools.scripts"]
+packages = ["FATtools", "FATtools.NTFS", "FATtools.scripts"]
 
 [tool.setuptools.dynamic]
 version = {attr = "FATtools.version.__version__"}


### PR DESCRIPTION
FATtools now supports NTFS via a submodule, which is a first for this project. Considering the submodule is indiscriminately imported regardless of the type of volumes to work with, missing the submodule means that no command works at all.

Because the package built by the build system didn't contain the NTFS submodule, all PYPI releases between v1.1.0 and now are broken. This fixes the issue by making sure the submodule is indeed included in the built package.

Fixes: c9509ec58429 ("Fixed and enhanced with basic NTFS support")