### PR TITLE
Migrate to PEP-639 and add GPL license text to PYPI package

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools"]
+requires = ["setuptools >= 77.0.3"]
 build-backend = "setuptools.build_meta"
 
 [project]
@@ -11,14 +11,13 @@ description = "Pure python tools for accessing FAT filesystem images and disks"
 readme = "README.MD"
 requires-python = ">=3.5"
 keywords = ["FAT", "disk","image"]
-license = {text = "GPL"}
+license = "GPL-3.0-only"
 classifiers = [
     'Programming Language :: Python :: 3',
     'Intended Audience :: Developers',
     'Intended Audience :: System Administrators',
     'Environment :: Win32 (MS Windows)',
     'Environment :: MacOS X',
-    'License :: OSI Approved :: GNU General Public License v3 (GPLv3)',
     'Operating System :: Microsoft :: Windows',
     'Operating System :: POSIX :: Linux',
     'Operating System :: MacOS :: MacOS X',

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,6 +12,7 @@ readme = "README.MD"
 requires-python = ">=3.5"
 keywords = ["FAT", "disk","image"]
 license = "GPL-3.0-only"
+license-files = ["gpl.txt"]
 classifiers = [
     'Programming Language :: Python :: 3',
     'Intended Audience :: Developers',


### PR DESCRIPTION
This migrates the build system to use PEP-639. If you look into the logs of the last few releases, you'll probably see something like:

```
 * Building wheel...
/tmp/build-env-5gmt14a9/lib/python3.13/site-packages/setuptools/config/_apply_pyprojecttoml.py:82: SetuptoolsDeprecationWarning: `project.license` as a TOML table is deprecated
!!

        ********************************************************************************
        Please use a simple string containing a SPDX expression for `project.license`. You can also use `project.license-files`. (Both options available on setuptools>=77.0.0).

        By 2026-Feb-18, you need to update your project and remove deprecated calls
        or your builds will no longer be supported.

        See https://packaging.python.org/en/latest/guides/writing-pyproject-toml/#license for details.
        ********************************************************************************

!!
  corresp(dist, value, root_dir)
/tmp/build-env-5gmt14a9/lib/python3.13/site-packages/setuptools/config/_apply_pyprojecttoml.py:61: SetuptoolsDeprecationWarning: License classifiers are deprecated.
!!

        ********************************************************************************
        Please consider removing the following classifiers in favor of a SPDX license expression:

        License :: OSI Approved :: GNU General Public License v3 (GPLv3)

        See https://packaging.python.org/en/latest/guides/writing-pyproject-toml/#license for details.
        ********************************************************************************
```

So migrating to PEP-639 fixes that.

**NOTE THAT THIS IS "CHANGING" THE LICENSE FROM GPLv3 to GPL-3.0-only**.  While the text in `gpl.txt` license seems to allow GPL-3.0-or-later, it only does so if the source code says "or any later version" somewhere. The only two places where the GPL is mentioned in the source code is in FATtools/__init__.py and FATtools/NTFS/__init__.py where it is NOT mentioned. Therefore, from my non-lawyer perspective, this means the project is under GPL-3.0-only and not GPL-3.0-or-later. Note that SPDX does not recognize GPLv3, it's either GPL-3.0-only or GPL-3.0-or-later, c.f. https://spdx.org/licenses/

While at it, my reading of the GPL-3.0-or-later license (though I still am not a lawyer) requires us to ship the license text with source code, so this fixes this non-compliance by adding the gpl text to the build package.

I haven't setup a test account on PYPI to verify that this does what it says it does, but locally installing the sdist and wheel packages copy the gpl license file in my `venv` (`venv/lib/python3.13/site-packages/fattools-1.1.5.dist-info/licenses/gpl.txt` and `venv/lib64/python3.13/site-packages/fattools-1.1.5.dist-info/licenses/gpl.txt`), so this seems ok?